### PR TITLE
fix: Conditional username field when realm uses email as username and language change

### DIFF
--- a/themes/ilhasoft/login/login-form.ftl
+++ b/themes/ilhasoft/login/login-form.ftl
@@ -5,7 +5,7 @@
         <unnnic-form-element
             label="<#if !realm.loginWithEmailAllowed>${msg('username')}<#elseif !realm.registrationEmailAsUsername>${msg('usernameOrEmail')}<#else>${msg('email')}</#if>">
             <unnnic-input :disabled="!!VTEXAppEmail" ref="loginUsername" v-model="usernameInput"
-                placeholder="${msg('placeholderLoginName')}" name="username" autocomplete="username"
+                placeholder="<#if realm.registrationEmailAsUsername>${msg('placeholderLoginEmail')}<#else>${msg('placeholderLoginName')}</#if>" name="username" autocomplete="<#if realm.registrationEmailAsUsername>email<#else>username</#if>"
                 :disabled="<#if usernameEditDisabled??>true<#else>false</#if>" autofocus @input="usernameInput = sanitizeHtml(usernameInput)"></unnnic-input>
         </unnnic-form-element>
 

--- a/themes/ilhasoft/login/messages/messages_en.properties
+++ b/themes/ilhasoft/login/messages/messages_en.properties
@@ -15,6 +15,7 @@ loginResetInstructions=To reset your password, enter your email.
 
 minCharacters=You need at least 3 characters
 placeholderLoginName=Enter your username or e-mail
+placeholderLoginEmail=Enter your e-mail
 placeholderLoginPassword=Enter your password
 placeholderRegisterFirstName=Enter your first name
 placeholderRegisterLastName=Enter your last name

--- a/themes/ilhasoft/login/messages/messages_es.properties
+++ b/themes/ilhasoft/login/messages/messages_es.properties
@@ -34,6 +34,7 @@ noAccount=¿No tiene una cuenta?
 
 minCharacters=Necesita al menos 3 caracteres
 placeholderLoginName=Introduzca su nombre de usuario o dirección de correo electrónico
+placeholderLoginEmail=Introduzca su correo electrónico
 placeholderLoginPassword=Introduzca su contraseña
 placeholderRegisterFirstName=Introduzca su nombre
 placeholderRegisterLastName=Introduzca su apellido

--- a/themes/ilhasoft/login/messages/messages_pt_BR.properties
+++ b/themes/ilhasoft/login/messages/messages_pt_BR.properties
@@ -15,6 +15,7 @@ createAccount=Criar uma conta
 
 minCharacters=Precisa de, no mínimo, 3 caracteres
 placeholderLoginName=Digite o seu usuário ou e-mail
+placeholderLoginEmail=Digite seu e-mail
 placeholderLoginPassword=Digite a sua senha
 placeholderRegisterFirstName=Digite seu nome
 placeholderRegisterLastName=Digite seu sobrenome

--- a/themes/ilhasoft/login/template.ftl
+++ b/themes/ilhasoft/login/template.ftl
@@ -222,8 +222,8 @@
                 </#if>
                 <#if displayLoginFormScriptsAndStyles>
                     canLogin() {
-                        return this.isEmailValid(this.usernameInput) && 
-                               this.passwordInput && this.passwordInput.trim().length > 0;
+                        const usernameValid = <#if realm.registrationEmailAsUsername>this.isEmailValid(this.usernameInput)<#else>this.usernameInput && this.usernameInput.trim().length > 0</#if>;
+                        return usernameValid && this.passwordInput && this.passwordInput.trim().length > 0;
                     },
                 </#if>
                 supportedLanguages() {

--- a/themes/ilhasoft/login/template.ftl
+++ b/themes/ilhasoft/login/template.ftl
@@ -54,8 +54,8 @@
         <#if realm.internationalizationEnabled  && locale.supported?size gt 1>
             <div class="language-select top">
                 <unnnic-language-select
-                    :value="language"
-                    @input="changeLanguage"
+                    :model-value="language"
+                    @update:model-value="changeLanguage"
                     position="bottom"
                     :supported-languages="supportedLanguages"
                 ></unnnic-language-select>


### PR DESCRIPTION
### Context
When the realm is set to "Email as username" (registrationEmailAsUsername), the first field is only email; when it's not set, the user can enter either username or email. The theme consistently passed email validation and a single placeholder, which didn't reflect the realm's configuration.

Also, the `unnnic-language-select` component was corrected, previously using Vue 2's `value` and `@input` patterns, now using `model-value` and `@update:model-value`.