### PR TITLE
refactor: remove unused social media links from email templates

### DIFF
--- a/themes/ilhasoft/email/html/email-test.ftl
+++ b/themes/ilhasoft/email/html/email-test.ftl
@@ -21,14 +21,6 @@
           <footer style="width: 670px; border-top: 1px solid #E0E0E0; border-bottom: 8px solid #1F1F1F;margin: auto; text-align: center;">
  
             <img src="https://weni-media-sp.s3-sa-east-1.amazonaws.com/logo/Logo-small.png" alt="Logo" height="42px" style="margin: 15px 0;"/>
-
-
-            <div style="width: 450px; font-size: 12px;line-height: 20px;margin: auto;">
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">Visite o nosso site</a>
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">Facebook</a>
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">Instagram</a>
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">Twitter</a>
-            </div>
           
           ${msg("emailCopyright", .now?string("yyyy"))?no_esc}
           

--- a/themes/ilhasoft/email/html/email-verification.ftl
+++ b/themes/ilhasoft/email/html/email-verification.ftl
@@ -36,14 +36,6 @@
           <footer style="width: 670px; border-top: 1px solid #E0E0E0; border-bottom: 8px solid #1F1F1F;margin: auto; text-align: center;">
  
             <img src="https://weni-media-sp.s3-sa-east-1.amazonaws.com/logo/Logo-small.png" alt="Logo" height="42px" style="margin: 15px 0;"/>
-
-
-            <div style="width: 450px; font-size: 12px;line-height: 20px;margin: auto;">
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">${msg("emailAccessOurSite")?no_esc}</a>
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">Facebook</a>
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">Instagram</a>
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">Twitter</a>
-            </div>
           
           ${msg("emailCopyright", .now?string("yyyy"))?no_esc}
           

--- a/themes/ilhasoft/email/html/event-login_error.ftl
+++ b/themes/ilhasoft/email/html/event-login_error.ftl
@@ -24,14 +24,6 @@
           <footer style="width: 670px; border-top: 1px solid #E0E0E0; border-bottom: 8px solid #1F1F1F;margin: auto; text-align: center;">
  
             <img src="https://weni-media-sp.s3-sa-east-1.amazonaws.com/logo/Logo-small.png" alt="Logo" height="42px" style="margin: 15px 0;"/>
-
-
-            <div style="width: 450px; font-size: 12px;line-height: 20px;margin: auto;">
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">${msg("emailAccessOurSite")?no_esc}</a>
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">Facebook</a>
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">Instagram</a>
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">Twitter</a>
-            </div>
           
           ${msg("emailCopyright", .now?string("yyyy"))?no_esc}
         </footer>

--- a/themes/ilhasoft/email/html/event-remove_totp.ftl
+++ b/themes/ilhasoft/email/html/event-remove_totp.ftl
@@ -24,14 +24,6 @@
           <footer style="width: 670px; border-top: 1px solid #E0E0E0; border-bottom: 8px solid #1F1F1F;margin: auto; text-align: center;">
  
             <img src="https://weni-media-sp.s3-sa-east-1.amazonaws.com/logo/Logo-small.png" alt="Logo" height="42px" style="margin: 15px 0;"/>
-
-
-            <div style="width: 450px; font-size: 12px;line-height: 20px;margin: auto;">
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">${msg("emailAccessOurSite")?no_esc}</a>
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">Facebook</a>
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">Instagram</a>
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">Twitter</a>
-            </div>
           
           ${msg("emailCopyright", .now?string("yyyy"))?no_esc}
         </footer>

--- a/themes/ilhasoft/email/html/event-update_password.ftl
+++ b/themes/ilhasoft/email/html/event-update_password.ftl
@@ -24,14 +24,6 @@
           <footer style="width: 670px; border-top: 1px solid #E0E0E0; border-bottom: 8px solid #1F1F1F;margin: auto; text-align: center;">
  
             <img src="https://weni-media-sp.s3-sa-east-1.amazonaws.com/logo/Logo-small.png" alt="Logo" height="42px" style="margin: 15px 0;"/>
-
-
-            <div style="width: 450px; font-size: 12px;line-height: 20px;margin: auto;">
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">${msg("emailAccessOurSite")?no_esc}</a>
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">Facebook</a>
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">Instagram</a>
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">Twitter</a>
-            </div>
           
           ${msg("emailCopyright", .now?string("yyyy"))?no_esc}
         </footer>

--- a/themes/ilhasoft/email/html/event-update_totp.ftl
+++ b/themes/ilhasoft/email/html/event-update_totp.ftl
@@ -24,14 +24,6 @@
           <footer style="width: 670px; border-top: 1px solid #E0E0E0; border-bottom: 8px solid #1F1F1F;margin: auto; text-align: center;">
  
             <img src="https://weni-media-sp.s3-sa-east-1.amazonaws.com/logo/Logo-small.png" alt="Logo" height="42px" style="margin: 15px 0;"/>
-
-
-            <div style="width: 450px; font-size: 12px;line-height: 20px;margin: auto;">
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">${msg("emailAccessOurSite")?no_esc}</a>
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">Facebook</a>
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">Instagram</a>
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">Twitter</a>
-            </div>
           
           ${msg("emailCopyright", .now?string("yyyy"))?no_esc}
         </footer>

--- a/themes/ilhasoft/email/html/executeActions.ftl
+++ b/themes/ilhasoft/email/html/executeActions.ftl
@@ -27,14 +27,6 @@
           <footer style="width: 670px; border-top: 1px solid #E0E0E0; border-bottom: 8px solid #1F1F1F;margin: auto; text-align: center;">
  
             <img src="https://weni-media-sp.s3-sa-east-1.amazonaws.com/logo/Logo-small.png" alt="Logo" height="42px" style="margin: 15px 0;"/>
-
-
-            <div style="width: 450px; font-size: 12px;line-height: 20px;margin: auto;">
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">${msg("emailAccessOurSite")?no_esc}</a>
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">Facebook</a>
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">Instagram</a>
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">Twitter</a>
-            </div>
           
           ${msg("emailCopyright", .now?string("yyyy"))?no_esc}
         </footer>

--- a/themes/ilhasoft/email/html/identity-provider-link.ftl
+++ b/themes/ilhasoft/email/html/identity-provider-link.ftl
@@ -24,14 +24,6 @@
           <footer style="width: 670px; border-top: 1px solid #E0E0E0; border-bottom: 8px solid #1F1F1F;margin: auto; text-align: center;">
  
             <img src="https://weni-media-sp.s3-sa-east-1.amazonaws.com/logo/Logo-small.png" alt="Logo" height="42px" style="margin: 15px 0;"/>
-
-
-            <div style="width: 450px; font-size: 12px;line-height: 20px;margin: auto;">
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">${msg("emailAccessOurSite")?no_esc}</a>
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">Facebook</a>
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">Instagram</a>
-              <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">Twitter</a>
-            </div>
           
           ${msg("emailCopyright", .now?string("yyyy"))?no_esc}
         </footer>

--- a/themes/ilhasoft/email/html/password-reset.ftl
+++ b/themes/ilhasoft/email/html/password-reset.ftl
@@ -27,13 +27,6 @@
               <footer style="width: 670px; border-top: 1px solid #E0E0E0; border-bottom: 8px solid #1F1F1F;margin: auto; text-align: center;">
  
                 <img src="https://weni-media-sp.s3-sa-east-1.amazonaws.com/logo/Logo-small.png" alt="Logo" height="42px" style="margin: 15px 0;"/>
-  
-                <div style="width: 450px; font-size: 12px;line-height: 20px;margin: auto;">
-                  <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">${msg("emailAccessOurSite")?no_esc}</a>
-                  <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">Facebook</a>
-                  <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">Instagram</a>
-                  <a style="cursor: pointer;margin-right: 10px;color: #ADADAD;">Twitter</a>
-                </div>
               
               ${msg("emailCopyright", .now?string("yyyy"))?no_esc}
               


### PR DESCRIPTION
## Summary
- Remove non-functional social media links (website, Facebook, Instagram, Twitter) from the footer of all 9 HTML email templates
- The `<a>` tags had no `href` attributes and served no purpose, only adding visual clutter to the emails

## Test plan
- [ ] Verify email templates render correctly without the social media links section
- [ ] Confirm no FTL syntax errors by testing email sending (e.g., password reset, email verification)

Made with [Cursor](https://cursor.com)